### PR TITLE
Fix dynamic alias

### DIFF
--- a/lib/renderer.ex
+++ b/lib/renderer.ex
@@ -49,7 +49,7 @@ defmodule MobileDoc.Renderer do
 
   # Render valid card
   defp render_card(card, payload) when not is_nil(card) do
-    card.Html.setup(_buffer = [], {}, {}, payload)
+    Module.concat(card, Html).setup(_buffer = [], {}, {}, payload)
     |> Enum.reduce(Document.create_element("div"), fn (string, card_element) ->
       card_element
       |> Element.append_child(Document.create_text_node(string))

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,2 @@
-%{"fs": {:hex, :fs, "0.9.2"},
-  "mix_test_watch": {:hex, :mix_test_watch, "0.2.1"}}
+%{"fs": {:hex, :fs, "0.9.2", "ed17036c26c3f70ac49781ed9220a50c36775c6ca2cf8182d123b6566e49ec59", [:rebar], []},
+  "mix_test_watch": {:hex, :mix_test_watch, "0.2.1", "c8f62710ddf32a6ca3450877e4a0a32b7055524ba6efe2180cfb34102b13b65c", [:mix], [{:fs, "~> 0.9.1", [hex: :fs, optional: false]}]}}


### PR DESCRIPTION
Fixes the following error message:

`invalid alias: "card.Html". If you wanted to define an alias, an alias must expand to an atom at compile time but it did not, you may use Module.concat/2 to build it at runtime. If instead you wanted to invoke a function or access a field, wrap the function or field name in double quotes`
